### PR TITLE
Make server detail box float.

### DIFF
--- a/web/static/aprs2status.css
+++ b/web/static/aprs2status.css
@@ -67,6 +67,7 @@ li.poll-log pre {
 	z-index: 100;
 	margin: 0;
 	padding: 15px;
+	max-width: 90%;
 }
 
 #popup1-content > .list-group {

--- a/web/static/aprs2status.css
+++ b/web/static/aprs2status.css
@@ -57,3 +57,24 @@ li.poll-log pre {
 	margin: 0px;
 	background: none;
 }
+
+/* server detail */
+
+#popup1-content {
+	position: fixed;
+	top: 0;
+	right: 0;
+	z-index: 100;
+	margin: 0;
+	padding: 15px;
+}
+
+#popup1-content > .list-group {
+	max-height: 90vh;
+	overflow-y: auto;
+	box-shadow: 0 3px 5px rgba(0,0,0,0.125);
+}
+
+#popup1-content .pull-right > .glyphicon {
+	margin-left: 15px;
+}


### PR DESCRIPTION
The server detail box is currently located above the server list and is not visible until a server is selected. This causes the server list to get pushed down the page when the box becomes visible. To view the server details, the user has to scroll all the way back to the top of the page. This is confusing.

This patch fixes the server details box to the top right of the viewport, so that it is immediately visible after clicking a server and does not cause the server list to shift down the page.
